### PR TITLE
don't publish vendor/ or Gopkg.lock

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@
 
 # IDE config
 .idea*
+
+# vendor and dep lock file
+vendor/
+Gopkg.lock


### PR DESCRIPTION
Signed-off-by: jeffvance <jeff.h.vance@gmail.com>
The goal is to make it easier to consume this lib and therefore we don't want to export our vendor or lock files.