### PR TITLE
allow obc to have no bucket related fields for "brownfield"

### DIFF
--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
@@ -17,7 +17,7 @@ type mapper interface {
 const (
 	AwsKeyField        = "AWS_ACCESS_KEY_ID"
 	AwsSecretField     = "AWS_SECRET_ACCESS_KEY"
-	StorageClassBucket = "BUCKET_NAME"
+	StorageClassBucket = "bucketName"
 )
 
 // AccessKeys is an Authentication type for passing AWS S3 style key pairs from the provisioner to the reconciler

--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
@@ -30,7 +30,7 @@ type ObjectBucketClaimSpec struct {
 	// GenerateBucketName (recommended) a prefix for a bucket name to be
 	// followed by a hyphen and 5 random characters. Protects against
 	// in-store name collisions.
-	GeneratBucketName string `json:"generateBucketName,omitempty"`
+	GenerateBucketName string `json:"generateBucketName,omitempty"`
 	// SSL whether connection to the bucket requires SSL Authentication or not
 	SSL bool `json:"ssl"`
 	// Generic predefined bucket ACLs for use by provisioners

--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -287,7 +287,7 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 
 	setObjectBucketName(ob, key)
 	ob.Spec.StorageClassName = obc.Spec.StorageClassName
-	ob.Spec.ClaimRef, err = claimRefForKey(key)
+	ob.Spec.ClaimRef, err = claimRefForKey(key, c.libClientset)
 	ob.Spec.ReclaimPolicy = options.ReclaimPolicy
 	ob.SetFinalizers([]string{finalizer})
 

--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -287,7 +287,7 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 
 	setObjectBucketName(ob, key)
 	ob.Spec.StorageClassName = obc.Spec.StorageClassName
-	ob.Spec.ClaimRef, err = claimRefForKey(key, c.libClientset)
+	ob.Spec.ClaimRef, err = claimRefForKey(key)
 	ob.Spec.ReclaimPolicy = options.ReclaimPolicy
 	ob.SetFinalizers([]string{finalizer})
 

--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -217,6 +217,10 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 		err       error
 	)
 
+	if !shouldProvision(obc) {
+		return nil
+	}
+
 	// If the storage class contains the name of the bucket then we create access
 	// to an existing bucket. If the bucket name does not appear in the storage
 	// class then we dynamically provision a new bucket.
@@ -246,10 +250,6 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 	}
 	if len(bucketName) == 0 {
 		return fmt.Errorf("bucket name missing")
-	}
-
-	if !shouldProvision(obc) {
-		return nil
 	}
 
 	options := &api.BucketOptions{

--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -217,10 +217,6 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 		err       error
 	)
 
-	if !shouldProvision(obc) {
-		return nil
-	}
-
 	// If the storage class contains the name of the bucket then we create access
 	// to an existing bucket. If the bucket name does not appear in the storage
 	// class then we dynamically provision a new bucket.

--- a/pkg/provisioner/helpers.go
+++ b/pkg/provisioner/helpers.go
@@ -26,13 +26,9 @@ func makeObjectReference(claim *v1alpha1.ObjectBucketClaim) *corev1.ObjectRefere
 }
 
 func shouldProvision(obc *v1alpha1.ObjectBucketClaim) bool {
-	logD.Info("validating claim for provisioning")
+	logD.Info("validating claim for provisioning obc", obc.Name)
 	if obc.Spec.ObjectBucketName != "" {
 		log.Info("provisioning already completed", "ObjectBucket", obc.Spec.ObjectBucketName)
-		return false
-	}
-	if obc.Spec.StorageClassName == "" {
-		log.Info("OBC did not provide a storage class, cannot provision")
 		return false
 	}
 	return true

--- a/pkg/provisioner/helpers.go
+++ b/pkg/provisioner/helpers.go
@@ -126,15 +126,18 @@ func obNameFromClaimKey(key string) (string, error) {
 func composeBucketName(obc *v1alpha1.ObjectBucketClaim) (string, error) {
 	logD.Info("determining bucket name")
 	// XOR BucketName and GenerateBucketName
-	if (obc.Spec.BucketName == "") == (obc.Spec.GeneratBucketName == "") {
+	if obc.Spec.BucketName == "" && obc.Spec.GenerateBucketName == "" {
 		return "", fmt.Errorf("expected either bucketName or generateBucketName defined")
+	}
+	if obc.Spec.BucketName != "" && obc.Spec.GenerateBucketName != "" {
+		return "", fmt.Errorf("cannot define both bucketName and generateBucketName")
 	}
 	bucketName := obc.Spec.BucketName
 	if bucketName == "" {
-		logD.Info("bucket name is empty, generating")
-		bucketName = generateBucketName(obc.Spec.GeneratBucketName)
+		logD.Info("bucket name is empty, generating...")
+		bucketName = generateBucketName(obc.Spec.GenerateBucketName)
+		logD.Info("generated bucket name", "name", bucketName)
 	}
-	logD.Info("bucket name generated", "name", bucketName)
 	return bucketName, nil
 }
 

--- a/pkg/provisioner/reconiler.go
+++ b/pkg/provisioner/reconiler.go
@@ -208,7 +208,7 @@ package provisioner
 //
 // 	setObjectBucketName(ob, key)
 // 	ob.Spec.StorageClassName = obc.Spec.StorageClassName
-// 	ob.Spec.ClaimRef, err = claimRefForKey(key, r.internalClient)
+// 	ob.Spec.ClaimRef, err = claimRefForKey(key)
 // 	ob.Spec.ReclaimPolicy = options.ReclaimPolicy
 // 	ob.SetFinalizers([]string{finalizer})
 //

--- a/pkg/provisioner/reconiler.go
+++ b/pkg/provisioner/reconiler.go
@@ -208,7 +208,7 @@ package provisioner
 //
 // 	setObjectBucketName(ob, key)
 // 	ob.Spec.StorageClassName = obc.Spec.StorageClassName
-// 	ob.Spec.ClaimRef, err = claimRefForKey(key)
+// 	ob.Spec.ClaimRef, err = claimRefForKey(key, r.internalClient)
 // 	ob.Spec.ReclaimPolicy = options.ReclaimPolicy
 // 	ob.SetFinalizers([]string{finalizer})
 //


### PR DESCRIPTION
needed for brownfield bkts.