### PR TITLE
fix OwnerReference Kind and APIVersion from pr 115

### DIFF
--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
@@ -6,6 +6,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const ObjectBucketKind = "ObjectBucket"
+
+func ObjectBucketGVK() schema.GroupVersionKind {
+	return GroupKindVersion(ObjectBucketKind)
+}
+
 type mapper interface {
 	toMap() map[string]string
 }
@@ -108,12 +114,6 @@ const (
 type ObjectBucketStatus struct {
 	Phase      ObjectBucketStatusPhase `json:"phase"`
 	Conditions corev1.ConditionStatus  `json:"conditions"`
-}
-
-const ObjectBucketKind = "ObjectBucket"
-
-func ObjectBucketGVK() schema.GroupVersionKind {
-	return GroupKindVersion(ObjectBucketKind)
 }
 
 // +genclient

--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
@@ -3,6 +3,7 @@ package v1alpha1
 import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 type mapper interface {
@@ -81,7 +82,7 @@ type Connection struct {
 type ObjectBucketSpec struct {
 	StorageClassName string                                `json:"storageClassName"`
 	ReclaimPolicy    *corev1.PersistentVolumeReclaimPolicy `json:"reclaimPolicy"`
-	ClaimRef         *corev1.ObjectReference	       `json:"claimRef"`
+	ClaimRef         *corev1.ObjectReference               `json:"claimRef"`
 	*Connection      `json:"Connection"`
 }
 
@@ -107,6 +108,12 @@ const (
 type ObjectBucketStatus struct {
 	Phase      ObjectBucketStatusPhase `json:"phase"`
 	Conditions corev1.ConditionStatus  `json:"conditions"`
+}
+
+const ObjectBucketKind = "ObjectBucket"
+
+func ObjectBucketGVK() schema.GroupVersionKind {
+	return GroupKindVersion(ObjectBucketKind)
 }
 
 // +genclient

--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
@@ -2,6 +2,7 @@ package v1alpha1
 
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
 // BucketCannedACL strictly types pre-defined S3 bucket ACLs.  Provisioners are recommended to constrain these ACLs
@@ -84,6 +85,12 @@ type ObjectBucketClaim struct {
 
 	Spec   ObjectBucketClaimSpec   `json:"spec,omitempty"`
 	Status ObjectBucketClaimStatus `json:"status,omitempty"`
+}
+
+const ObjectBucketClaimKind = "ObjectBucketClaim"
+
+func ObjectBucketClaimGVK() schema.GroupVersionKind {
+	return GroupKindVersion(ObjectBucketClaimKind)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
@@ -5,6 +5,12 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
+const ObjectBucketClaimKind = "ObjectBucketClaim"
+
+func ObjectBucketClaimGVK() schema.GroupVersionKind {
+	return GroupKindVersion(ObjectBucketClaimKind)
+}
+
 // BucketCannedACL strictly types pre-defined S3 bucket ACLs.  Provisioners are recommended to constrain these ACLs
 // scoped to the unique bucket that was created for the request. They are a subset of canned ACLs from AWS S3's
 // definitions of canned ACLs at https://docs.aws.amazon.com/AmazonS3/latest/dev/acl-overview.html#canned-acl
@@ -85,12 +91,6 @@ type ObjectBucketClaim struct {
 
 	Spec   ObjectBucketClaimSpec   `json:"spec,omitempty"`
 	Status ObjectBucketClaimStatus `json:"status,omitempty"`
-}
-
-const ObjectBucketClaimKind = "ObjectBucketClaim"
-
-func ObjectBucketClaimGVK() schema.GroupVersionKind {
-	return GroupKindVersion(ObjectBucketClaimKind)
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/objectbucket.io/v1alpha1/register.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/register.go
@@ -14,9 +14,11 @@ import (
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: objectbucketio.GroupName, Version: "v1alpha1"}
 
-var OBCgroupVersion = SchemeGroupVersion.Group + "/" + SchemeGroupVersion.Version
+const Version = "v1alpha1"
 
-var OBCgvk = schema.GroupVersionKind{Group: SchemeGroupVersion.Group, Version: SchemeGroupVersion.Version, Kind: "ObjectBucketClaim"}
+func GroupKindVersion(kind string) schema.GroupVersionKind {
+	return SchemeGroupVersion.WithKind(kind)
+}
 
 // Kind takes an unqualified kind and returns back a Group qualified GroupKind
 func Kind(kind string) schema.GroupKind {

--- a/pkg/apis/objectbucket.io/v1alpha1/register.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/register.go
@@ -14,6 +14,10 @@ import (
 // SchemeGroupVersion is group version used to register these objects
 var SchemeGroupVersion = schema.GroupVersion{Group: objectbucketio.GroupName, Version: "v1alpha1"}
 
+var OBCgroupVersion = SchemeGroupVersion.Group + "/" + SchemeGroupVersion.Version
+
+var OBCgvk = schema.GroupVersionKind{Group: SchemeGroupVersion.Group, Version: SchemeGroupVersion.Version, Kind: "ObjectBucketClaim"}
+
 // Kind takes an unqualified kind and returns back a Group qualified GroupKind
 func Kind(kind string) schema.GroupKind {
 	return SchemeGroupVersion.WithKind(kind).GroupKind()

--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -302,8 +302,8 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 		return err
 	}
 
-	// NOTE: do not move ob create/update calls before secret or vice versa.  spec.Authentication is lost after create/update, which
-	// break secret creation
+	// Note: do not move ob create/update calls before secret or vice versa.
+	//   spec.Authentication is lost after create/update, which break secret creation
 	if ob, err = createObjectBucket(ob, c.libClientset, defaultRetryBaseInterval, defaultRetryTimeout); err != nil {
 		return err
 	}
@@ -317,6 +317,7 @@ func (c *Controller) handleProvisionClaim(key string, obc *v1alpha1.ObjectBucket
 	if _, err = updateClaim(c.libClientset, obc, defaultRetryBaseInterval, defaultRetryTimeout); err != nil {
 		return err
 	}
+
 	log.Info("provisioning succeeded")
 	return nil
 }

--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -345,8 +345,8 @@ func (c *Controller) handleDeleteClaim(key string) error {
 		return nil
 	}
 
-	// ok to call Delete or Revoke and then delete generated k8s resources
-	// Note: if Delete or Revoke return an error we do not try to delete resources
+	// call Delete or Revoke and then delete generated k8s resources
+	// Note: if Delete or Revoke return err then we do not try to delete resources
 	ob, err = updateObjectBucketPhase(c.libClientset, ob, v1alpha1.ObjectBucketClaimStatusPhaseReleased, defaultRetryBaseInterval, defaultRetryTimeout)
 	if err != nil {
 		return err

--- a/pkg/provisioner/helpers.go
+++ b/pkg/provisioner/helpers.go
@@ -17,11 +17,14 @@ import (
 )
 
 func makeObjectReference(claim *v1alpha1.ObjectBucketClaim) *corev1.ObjectReference {
+
+	groupVersion, kind := claim.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
 	return &corev1.ObjectReference{
-		Kind:      claim.Kind,
-		Name:      claim.Name,
-		Namespace: claim.Namespace,
-		UID:       claim.UID,
+		APIVersion: groupVersion,
+		Kind:       kind,
+		Name:       claim.Name,
+		Namespace:  claim.Namespace,
+		UID:        claim.UID,
 	}
 }
 
@@ -34,8 +37,8 @@ func makeOwnerReference(claim *v1alpha1.ObjectBucketClaim) metav1.OwnerReference
 	return metav1.OwnerReference{
 		APIVersion:         groupVersion,
 		Kind:               kind,
-		Name:               claim.GetName(),
-		UID:                claim.GetUID(),
+		Name:               claim.Name,
+		UID:                claim.UID,
 		BlockOwnerDeletion: &blockOwnerDeletion,
 		Controller:         &isController,
 	}

--- a/pkg/provisioner/helpers.go
+++ b/pkg/provisioner/helpers.go
@@ -8,7 +8,6 @@ import (
 
 	corev1 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 
@@ -18,10 +17,9 @@ import (
 
 func makeObjectReference(claim *v1alpha1.ObjectBucketClaim) *corev1.ObjectReference {
 
-	groupVersion, kind := claim.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
 	return &corev1.ObjectReference{
-		APIVersion: groupVersion,
-		Kind:       kind,
+		APIVersion: v1alpha1.OBCgroupVersion,
+		Kind:       v1alpha1.OBCgvk.Kind,
 		Name:       claim.Name,
 		Namespace:  claim.Namespace,
 		UID:        claim.UID,
@@ -30,13 +28,12 @@ func makeObjectReference(claim *v1alpha1.ObjectBucketClaim) *corev1.ObjectRefere
 
 func makeOwnerReference(claim *v1alpha1.ObjectBucketClaim) metav1.OwnerReference {
 
-	groupVersion, kind := claim.GetObjectKind().GroupVersionKind().ToAPIVersionAndKind()
 	blockOwnerDeletion := true
 	isController := true
 
 	return metav1.OwnerReference{
-		APIVersion:         groupVersion,
-		Kind:               kind,
+		APIVersion:	    v1alpha1.OBCgroupVersion,
+		Kind:		    v1alpha1.OBCgvk.Kind,
 		Name:               claim.Name,
 		UID:                claim.UID,
 		BlockOwnerDeletion: &blockOwnerDeletion,
@@ -71,12 +68,10 @@ func claimForKey(key string, c versioned.Interface) (obc *v1alpha1.ObjectBucketC
 
 	obc, err = c.ObjectbucketV1alpha1().ObjectBucketClaims(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
-		if errors.IsNotFound(err) {
-			return nil, err
-		}
-		return nil, fmt.Errorf("error getting claim: %v", err)
+		return nil, err
 	}
-	return obc.DeepCopy(), nil
+	// WHY DeepCopy?? return obc.DeepCopy(), nil
+	return obc, nil
 }
 
 // Return true if this storage class is for a new bucket vs an existing bucket.

--- a/pkg/provisioner/helpers.go
+++ b/pkg/provisioner/helpers.go
@@ -18,8 +18,8 @@ import (
 func makeObjectReference(claim *v1alpha1.ObjectBucketClaim) *corev1.ObjectReference {
 
 	return &corev1.ObjectReference{
-		APIVersion: v1alpha1.OBCgroupVersion,
-		Kind:       v1alpha1.OBCgvk.Kind,
+		APIVersion: v1alpha1.SchemeGroupVersion.String(),
+		Kind:       v1alpha1.ObjectBucketClaimGVK().Kind,
 		Name:       claim.Name,
 		Namespace:  claim.Namespace,
 		UID:        claim.UID,
@@ -32,8 +32,8 @@ func makeOwnerReference(claim *v1alpha1.ObjectBucketClaim) metav1.OwnerReference
 	isController := true
 
 	return metav1.OwnerReference{
-		APIVersion:	    v1alpha1.OBCgroupVersion,
-		Kind:		    v1alpha1.OBCgvk.Kind,
+		APIVersion:         v1alpha1.SchemeGroupVersion.String(),
+		Kind:               v1alpha1.ObjectBucketClaimGVK().Kind,
 		Name:               claim.Name,
 		UID:                claim.UID,
 		BlockOwnerDeletion: &blockOwnerDeletion,
@@ -65,13 +65,7 @@ func claimForKey(key string, c versioned.Interface) (obc *v1alpha1.ObjectBucketC
 	if err != nil {
 		return nil, err
 	}
-
-	obc, err = c.ObjectbucketV1alpha1().ObjectBucketClaims(ns).Get(name, metav1.GetOptions{})
-	if err != nil {
-		return nil, err
-	}
-	// WHY DeepCopy?? return obc.DeepCopy(), nil
-	return obc, nil
+	return c.ObjectbucketV1alpha1().ObjectBucketClaims(ns).Get(name, metav1.GetOptions{})
 }
 
 // Return true if this storage class is for a new bucket vs an existing bucket.

--- a/pkg/provisioner/resourcehandlers.go
+++ b/pkg/provisioner/resourcehandlers.go
@@ -97,8 +97,6 @@ func newCredentialsSecret(obc *v1alpha1.ObjectBucketClaim, auth *v1alpha1.Authen
 	}
 
 	secret.StringData = auth.ToMap()
-logD.Info("DEBUG *********", "obc meta", obc.ObjectMeta)
-logD.Info("DEBUG *********", "secret meta", secret.ObjectMeta)
 	return secret, nil
 }
 

--- a/pkg/provisioner/resourcehandlers.go
+++ b/pkg/provisioner/resourcehandlers.go
@@ -84,6 +84,7 @@ func newCredentialsSecret(obc *v1alpha1.ObjectBucketClaim, auth *v1alpha1.Authen
 	if auth == nil {
 		return nil, fmt.Errorf("got nil authentication, nothing to do")
 	}
+logD.Info("DEBUG *********", "obc meta", obc.ObjectMeta)
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -97,6 +98,7 @@ func newCredentialsSecret(obc *v1alpha1.ObjectBucketClaim, auth *v1alpha1.Authen
 	}
 
 	secret.StringData = auth.ToMap()
+logD.Info("DEBUG *********", "secret meta", secret.ObjectMeta)
 	return secret, nil
 }
 

--- a/pkg/provisioner/resourcehandlers.go
+++ b/pkg/provisioner/resourcehandlers.go
@@ -84,7 +84,6 @@ func newCredentialsSecret(obc *v1alpha1.ObjectBucketClaim, auth *v1alpha1.Authen
 	if auth == nil {
 		return nil, fmt.Errorf("got nil authentication, nothing to do")
 	}
-logD.Info("DEBUG *********", "obc meta", obc.ObjectMeta)
 
 	secret := &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
@@ -98,6 +97,7 @@ logD.Info("DEBUG *********", "obc meta", obc.ObjectMeta)
 	}
 
 	secret.StringData = auth.ToMap()
+logD.Info("DEBUG *********", "obc meta", obc.ObjectMeta)
 logD.Info("DEBUG *********", "secret meta", secret.ObjectMeta)
 	return secret, nil
 }

--- a/pkg/provisioner/util_test.go
+++ b/pkg/provisioner/util_test.go
@@ -493,7 +493,7 @@ func TestNewBucketConfigMap(t *testing.T) {
 // 					StorageClassName: className,
 // 					ReclaimPolicy:    &deletePolicy,
 // 					ClaimRef: &corev1.ObjectReference{
-// 						Kind:            "ObjectBucketClaim",
+// 						Kind:            v1alpha1.OBCKind,
 // 						Namespace:       testns,
 // 						Name:            testname,
 // 						UID:             "",

--- a/pkg/provisioner/util_test.go
+++ b/pkg/provisioner/util_test.go
@@ -493,11 +493,11 @@ func TestNewBucketConfigMap(t *testing.T) {
 // 					StorageClassName: className,
 // 					ReclaimPolicy:    &deletePolicy,
 // 					ClaimRef: &corev1.ObjectReference{
-// 						Kind:            v1alpha1.OBCKind,
+// 						Kind:            v1alpha1.ObjectBucketClaimGVK().Kind,
 // 						Namespace:       testns,
 // 						Name:            testname,
 // 						UID:             "",
-// 						APIVersion:      "objectbucket.io/v1alpha1",
+// 						APIVersion:      v1alpha1.SchemeGroupVersion.String(),
 // 					},
 // 					Connection: nil,
 // 				},


### PR DESCRIPTION
#115 had a bug where the OwnerReference Kind and APIVersion fields were empty which caused Secret and CM validation to fail.