### PR TITLE
inline objectBucket.spec.connection field

### DIFF
--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
@@ -89,7 +89,7 @@ type ObjectBucketSpec struct {
 	StorageClassName string                                `json:"storageClassName"`
 	ReclaimPolicy    *corev1.PersistentVolumeReclaimPolicy `json:"reclaimPolicy"`
 	ClaimRef         *corev1.ObjectReference               `json:"claimRef"`
-	*Connection      `json:"Connection"`
+	*Connection      `json:",inline"`
 }
 
 // ObjectBucketStatusPhase is set by the controller to save the state of the provisioning process.


### PR DESCRIPTION
changes the connection field of the ob spec to inline to pretty up the API yaml output:

```
kind: ObjectBucket
metadata:
  creationTimestamp: "2019-06-27T18:40:54Z"
  finalizers:
  - objectbucket.io/finalizer
  generation: 1
  name: obc-default-demo-bucket5h8zd
  resourceVersion: "48449"
  selfLink: /apis/objectbucket.io/v1alpha1/objectbuckets/obc-default-demo-bucket5h8zd
  uid: 18930706-990b-11e9-b39d-eeebd3468405
spec:
  additionalState:
    cephUser: ceph-user-Mat6VTPX
  claimRef: ...
  endpoint:
    additionalConfig: null
    bucketHost: rook-ceph-rgw-my-store.rook-ceph
    bucketName: jcope-provisioner-demo-e2faca49-5d21-47d0-b2db-8522f262f12c
    bucketPort: 80
    region: us-east-1
    ssl: false
    subRegion: ""
  reclaimPolicy: Delete
  storageClassName: rook-ceph-bucket
```
Signed-off-by: Jon Cope <jcope@redhat.com>