### PR TITLE
feat: add CRDs with apiextensions.k8s.io/v1 API version

### DIFF
--- a/deploy/crds/apiextensions-v1/objectbucket.io_objectbucketclaims.yaml
+++ b/deploy/crds/apiextensions-v1/objectbucket.io_objectbucketclaims.yaml
@@ -1,0 +1,92 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: objectbucketclaims.objectbucket.io
+spec:
+  group: objectbucket.io
+  names:
+    kind: ObjectBucketClaim
+    listKind: ObjectBucketClaimList
+    plural: objectbucketclaims
+    shortNames:
+    - obc
+    - obcs
+    singular: objectbucketclaim
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - description: StorageClass
+      jsonPath: .spec.storageClassName
+      name: StorageClass
+      type: string
+    - description: Phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ObjectBucketClaim is the Schema for the objectbucketclaims API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ObjectBucketClaimSpec defines the desired state of ObjectBucketClaim
+            properties:
+              additionalConfig:
+                additionalProperties:
+                  type: string
+                description: AdditionalConfig gives providers a location to set proprietary
+                  config values (tenant, namespace, etc)
+                type: object
+              bucketName:
+                description: BucketName (not recommended) the name of the bucket.  Caution!
+                  In-store bucket names may collide across namespaces.  If you define
+                  the name yourself, try to make it as unique as possible.
+                type: string
+              generateBucketName:
+                description: GenerateBucketName (recommended) a prefix for a bucket
+                  name to be followed by a hyphen and 5 random characters. Protects
+                  against in-store name collisions.
+                type: string
+              objectBucketName:
+                description: ObjectBucketName is the name of the object bucket resource.
+                  This is the authoritative determination for binding.
+                type: string
+              storageClassName:
+                description: StorageClass names the StorageClass object representing
+                  the desired provisioner and parameters
+                type: string
+            required:
+            - storageClassName
+            type: object
+          status:
+            description: ObjectBucketClaimStatus defines the observed state of ObjectBucketClaim
+            properties:
+              phase:
+                description: ObjectBucketClaimStatusPhase is set by the controller
+                  to save the state of the provisioning process.
+                type: string
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/deploy/crds/apiextensions-v1/objectbucket.io_objectbuckets.yaml
+++ b/deploy/crds/apiextensions-v1/objectbucket.io_objectbuckets.yaml
@@ -1,0 +1,183 @@
+---
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  annotations:
+    controller-gen.kubebuilder.io/version: v0.9.2
+  creationTimestamp: null
+  name: objectbuckets.objectbucket.io
+spec:
+  group: objectbucket.io
+  names:
+    kind: ObjectBucket
+    listKind: ObjectBucketList
+    plural: objectbuckets
+    shortNames:
+    - ob
+    - obs
+    singular: objectbucket
+  scope: Cluster
+  versions:
+  - additionalPrinterColumns:
+    - description: StorageClass
+      jsonPath: .spec.storageClassName
+      name: StorageClass
+      type: string
+    - description: ClaimNamespace
+      jsonPath: .spec.claimRef.namespace
+      name: ClaimNamespace
+      type: string
+    - description: ClaimName
+      jsonPath: .spec.claimRef.name
+      name: ClaimName
+      type: string
+    - description: ReclaimPolicy
+      jsonPath: .spec.reclaimPolicy
+      name: ReclaimPolicy
+      type: string
+    - description: Phase
+      jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: ObjectBucket is the Schema for the objectbuckets API
+        properties:
+          apiVersion:
+            description: 'APIVersion defines the versioned schema of this representation
+              of an object. Servers should convert recognized schemas to the latest
+              internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
+            type: string
+          kind:
+            description: 'Kind is a string value representing the REST resource this
+              object represents. Servers may infer this from the endpoint the client
+              submits requests to. Cannot be updated. In CamelCase. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+            type: string
+          metadata:
+            type: object
+          spec:
+            description: ObjectBucketSpec defines the desired state of ObjectBucket.
+              Fields defined here should be normal among all providers. Authentication
+              must be of a type defined in this package to pass type checks in reconciler
+            properties:
+              additionalState:
+                additionalProperties:
+                  type: string
+                type: object
+              claimRef:
+                description: 'ObjectReference contains enough information to let you
+                  inspect or modify the referred object. --- New uses of this type
+                  are discouraged because of difficulty describing its usage when
+                  embedded in APIs. 1. Ignored fields.  It includes many fields which
+                  are not generally honored.  For instance, ResourceVersion and FieldPath
+                  are both very rarely valid in actual usage. 2. Invalid usage help.  It
+                  is impossible to add specific help for individual usage.  In most
+                  embedded usages, there are particular restrictions like, "must refer
+                  only to types A and B" or "UID not honored" or "name must be restricted".
+                  Those cannot be well described when embedded. 3. Inconsistent validation.  Because
+                  the usages are different, the validation rules are different by
+                  usage, which makes it hard for users to predict what will happen.
+                  4. The fields are both imprecise and overly precise.  Kind is not
+                  a precise mapping to a URL. This can produce ambiguity during interpretation
+                  and require a REST mapping.  In most cases, the dependency is on
+                  the group,resource tuple and the version of the actual struct is
+                  irrelevant. 5. We cannot easily change it.  Because this type is
+                  embedded in many locations, updates to this type will affect numerous
+                  schemas.  Don''t make new APIs embed an underspecified API type
+                  they do not control. Instead of using this type, create a locally
+                  provided and used type that is well-focused on your reference. For
+                  example, ServiceReferences for admission registration: https://github.com/kubernetes/api/blob/release-1.17/admissionregistration/v1/types.go#L533
+                  .'
+                properties:
+                  apiVersion:
+                    description: API version of the referent.
+                    type: string
+                  fieldPath:
+                    description: 'If referring to a piece of an object instead of
+                      an entire object, this string should contain a valid JSON/Go
+                      field access statement, such as desiredState.manifest.containers[2].
+                      For example, if the object reference is to a container within
+                      a pod, this would take on a value like: "spec.containers{name}"
+                      (where "name" refers to the name of the container that triggered
+                      the event) or if no container name is specified "spec.containers[2]"
+                      (container with index 2 in this pod). This syntax is chosen
+                      only to have some well-defined way of referencing a part of
+                      an object. TODO: this design is not final and this field is
+                      subject to change in the future.'
+                    type: string
+                  kind:
+                    description: 'Kind of the referent. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#types-kinds'
+                    type: string
+                  name:
+                    description: 'Name of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names'
+                    type: string
+                  namespace:
+                    description: 'Namespace of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/namespaces/'
+                    type: string
+                  resourceVersion:
+                    description: 'Specific resourceVersion to which this reference
+                      is made, if any. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#concurrency-control-and-consistency'
+                    type: string
+                  uid:
+                    description: 'UID of the referent. More info: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#uids'
+                    type: string
+                type: object
+                x-kubernetes-map-type: atomic
+              endpoint:
+                description: Endpoint contains all connection relevant data that an
+                  app may require for accessing the bucket
+                properties:
+                  additionalConfig:
+                    additionalProperties:
+                      type: string
+                    type: object
+                  bucketHost:
+                    type: string
+                  bucketName:
+                    type: string
+                  bucketPort:
+                    type: integer
+                  region:
+                    type: string
+                  subRegion:
+                    type: string
+                required:
+                - additionalConfig
+                - bucketHost
+                - bucketName
+                - bucketPort
+                - region
+                - subRegion
+                type: object
+              reclaimPolicy:
+                description: PersistentVolumeReclaimPolicy describes a policy for
+                  end-of-life maintenance of persistent volumes.
+                type: string
+              storageClassName:
+                type: string
+            required:
+            - additionalState
+            - claimRef
+            - endpoint
+            - reclaimPolicy
+            - storageClassName
+            type: object
+          status:
+            description: ObjectBucketStatus defines the observed state of ObjectBucket
+            properties:
+              phase:
+                description: ObjectBucketStatusPhase is set by the controller to save
+                  the state of the provisioning process.
+                type: string
+            required:
+            - phase
+            type: object
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucket_types.go
@@ -134,6 +134,7 @@ type ObjectBucketStatus struct {
 // +genclient:nonNamespaced
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:scope=Cluster,shortName=ob;obs
 // +kubebuilder:printcolumn:name="StorageClass",type="string",JSONPath=".spec.storageClassName",description="StorageClass"
 // +kubebuilder:printcolumn:name="ClaimNamespace",type="string",JSONPath=".spec.claimRef.namespace",description="ClaimNamespace"

--- a/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
+++ b/pkg/apis/objectbucket.io/v1alpha1/objectbucketclaim_types.go
@@ -81,6 +81,7 @@ type ObjectBucketClaimStatus struct {
 // +genclient
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // +k8s:openapi-gen=true
+// +kubebuilder:subresource:status
 // +kubebuilder:resource:shortName=obc;obcs
 // +kubebuilder:printcolumn:name="StorageClass",type="string",JSONPath=".spec.storageClassName",description="StorageClass"
 // +kubebuilder:printcolumn:name="Phase",type="string",JSONPath=".status.phase",description="Phase"


### PR DESCRIPTION
This commit adds the ObjectBucket and ObjecktBucketClaims
CRDs with the GA version of the apiextensions since
apiextensions.k8s.io/v1beta1 has been removed in 1.22

To allow the operator to update the status of the resources, the /status
subresource is now added.

The CRDs were generated using controller-gen v0.9.2 with the following
command: controller-gen crd paths=./pkg/apis/objectbucket.io/...

Signed-off-by: Ludovic Cavajani <lcavajan@redhat.com>