### PR TITLE
fix issue creating new OB where status is missing

### DIFF
--- a/pkg/provisioner/controller.go
+++ b/pkg/provisioner/controller.go
@@ -388,12 +388,18 @@ func (c *obcController) handleProvisionClaim(key string, obc *v1alpha1.ObjectBuc
 	if err != nil {
 		return fmt.Errorf("error getting reference to OBC: %v", err)
 	}
-	ob.Status.Phase = v1alpha1.ObjectBucketStatusPhaseBound
 	ob, err = createOrUpdateObjectBucket(
 		ob,
 		c.libClientset)
 	if err != nil {
 		return fmt.Errorf("error creating or updating OB %q: %v", ob.Name, err)
+	}
+
+	// Status must be set/updated separately from OB spec
+	ob.Status.Phase = v1alpha1.ObjectBucketStatusPhaseBound
+	ob, err = c.libClientset.ObjectbucketV1alpha1().ObjectBuckets().UpdateStatus(context.TODO(), ob, metav1.UpdateOptions{})
+	if err != nil {
+		return fmt.Errorf("error updating OB %q status to %q", ob.Name, ob.Status.Phase)
 	}
 
 	// update OBC


### PR DESCRIPTION
When a Kubernetes object (like OB) is created, Kubernetes does not accept status. Status can only be set on an update. Update the provisioner to create and then update OBs so status is properly set for new OBCs.

Signed-off-by: Blaine Gardner <blaine.gardner@redhat.com>