### PR TITLE
Pass provided additional data config to config map

### DIFF
--- a/pkg/provisioner/resourcehandlers.go
+++ b/pkg/provisioner/resourcehandlers.go
@@ -63,7 +63,7 @@ func newBucketConfigMap(obc *v1alpha1.ObjectBucketClaim, ep *v1alpha1.Endpoint, 
 		return nil, fmt.Errorf("cannot construct configMap, got nil OBC")
 	}
 
-	return &corev1.ConfigMap{
+	cm := &corev1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:       composeConfigMapName(obc),
 			Namespace:  obc.Namespace,
@@ -80,7 +80,14 @@ func newBucketConfigMap(obc *v1alpha1.ObjectBucketClaim, ep *v1alpha1.Endpoint, 
 			bucketRegion:    ep.Region,
 			bucketSubRegion: ep.SubRegion,
 		},
-	}, nil
+	}
+	// if provided extra config - put it to configmap
+	if len(ep.AdditionalConfigData) > 0 {
+		for k, v := range ep.AdditionalConfigData {
+			cm.Data[k] = v
+		}
+	}
+	return cm, nil
 }
 
 // newCredentialsSecret returns a secret with data appropriate to the supported authenticaion

--- a/pkg/provisioner/resourcehandlers_test.go
+++ b/pkg/provisioner/resourcehandlers_test.go
@@ -272,6 +272,40 @@ func TestNewBucketConfigMap(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "with additional config defined",
+			args: args{
+				ep: &v1alpha1.Endpoint{
+					BucketHost: host,
+					BucketPort: port,
+					BucketName: name,
+					Region:     region,
+					SubRegion:  subRegion,
+					// check extra info passed
+					AdditionalDataConfig: map[string]string{
+						"SOME_ENV_VAR": "SOME_VALUE",
+					},
+				},
+				obc: &v1alpha1.ObjectBucketClaim{
+					ObjectMeta: objMeta,
+					Spec: v1alpha1.ObjectBucketClaimSpec{
+						BucketName: name,
+					},
+				},
+			},
+			want: &corev1.ConfigMap{
+				ObjectMeta: objMeta,
+				Data: map[string]string{
+					bucketName:      name,
+					bucketHost:      host,
+					bucketPort:      strconv.Itoa(port),
+					bucketRegion:    region,
+					bucketSubRegion: subRegion,
+					"SOME_ENV_VAR":  "SOME_VALUE",
+				},
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
In some cases need to pass extra env vars which can be consumed by envFrom config map for bucket.

Related-Issue: #232

Signed-Off-By: Denis Egorenko <degorenko@mirantis.com>